### PR TITLE
Add creation and deletion of dynamic DNS records

### DIFF
--- a/Automate/CloudFormsPOC/Integration/DynamicDNS/Methods.class/__class__.yaml
+++ b/Automate/CloudFormsPOC/Integration/DynamicDNS/Methods.class/__class__.yaml
@@ -1,0 +1,113 @@
+---
+object_type: class
+version: 1.0
+object:
+  attributes:
+    description: 
+    display_name: 
+    name: Methods
+    type: 
+    inherits: 
+    visibility: 
+    owner: 
+  schema:
+  - field:
+      aetype: attribute
+      name: servername
+      display_name: 
+      datatype: string
+      priority: 1
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: attribute
+      name: keyname
+      display_name: 
+      datatype: string
+      priority: 2
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: attribute
+      name: keyvalue
+      display_name: 
+      datatype: password
+      priority: 3
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: method1
+      display_name: 
+      datatype: string
+      priority: 4
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: method2
+      display_name: 
+      datatype: string
+      priority: 5
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 

--- a/Automate/CloudFormsPOC/Integration/DynamicDNS/Methods.class/__methods__/add_record.rb
+++ b/Automate/CloudFormsPOC/Integration/DynamicDNS/Methods.class/__methods__/add_record.rb
@@ -1,0 +1,56 @@
+# add_record.rb
+#
+# Author: Carsten Clasohm
+# License: GPL v3
+#
+# Description:
+#   Create a DNS A record for a VM name and an IP address that was acquired
+#   earlier in the provisioning process. Assumes that the provisioning dialog
+#   has a field for selecting the DNS domain.
+#
+#   Requires a DNS server like bind set up for dynamic DNS updates. For more
+#   information, see "man nsupdate".
+
+def error(msg)
+  $evm.log(:error, "#{msg}")
+  $evm.root['ae_result'] = 'error'
+  $evm.root['ae_reason'] = msg
+  exit MIQ_OK
+end
+
+begin
+  prov = $evm.root['miq_provision']
+  ws_values = prov.options[:ws_values]
+
+  vm = prov.vm
+
+  dns_domain = ws_values[:dns_domain]
+
+  fqdn = "#{vm.name}.#{dns_domain}"
+
+  ipaddress = prov.options[:ipaddr]
+
+  ddns_server = $evm.object['servername']
+  ddns_keyname = $evm.object['keyname']
+  ddns_keyvalue = $evm.object['keyvalue']
+
+  $evm.log(:info, "Creating DNS entry #{fqdn} A #{ipaddress}")
+  
+  IO.popen("nsupdate", 'r+') do |f|
+    f << <<-EOF
+      server #{ddns_server}
+      key #{ddns_keyname} #{ddns_keyvalue}
+      zone #{dns_domain}
+      update add #{fqdn} 86400 A #{ipaddress}
+      send
+    EOF
+
+    f.close_write
+  end
+
+  # This is used during VM retirement.
+  vm.custom_set('dns_domain', dns_domain)
+
+rescue => err
+  error("[#{err}]\n#{err.backtrace.join("\n")}")
+end

--- a/Automate/CloudFormsPOC/Integration/DynamicDNS/Methods.class/__methods__/add_record.yaml
+++ b/Automate/CloudFormsPOC/Integration/DynamicDNS/Methods.class/__methods__/add_record.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: add_record
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs: []

--- a/Automate/CloudFormsPOC/Integration/DynamicDNS/Methods.class/__methods__/delete_record.rb
+++ b/Automate/CloudFormsPOC/Integration/DynamicDNS/Methods.class/__methods__/delete_record.rb
@@ -1,0 +1,46 @@
+# delete_record.rb
+#
+# Author: Carsten Clasohm
+# License: GPL v3
+#
+# Description:
+#   During retirement, delete a VM's dynamic DNS entry.
+
+def error(msg)
+  $evm.log(:error, "#{msg}")
+  $evm.root['ae_result'] = 'error'
+  $evm.root['ae_reason'] = msg
+  exit MIQ_OK
+end
+
+begin
+  vm = $evm.root['vm']
+
+  # This was set by the add_record method.
+  dns_domain = vm.custom_get('dns_domain')
+
+  if dns_domain
+    fqdn = "#{vm.name}.#{dns_domain}"
+
+    ddns_server = $evm.object['servername']
+    ddns_keyname = $evm.object['keyname']
+    ddns_keyvalue = $evm.object['keyvalue']
+
+    $evm.log(:info, "Deleting DNS entry #{fqdn} A")
+
+    IO.popen("nsupdate", 'r+') do |f|
+      f << <<-EOF
+        server #{ddns_server}
+        key #{ddns_keyname} #{ddns_keyvalue}
+        zone #{dns_domain}
+        update delete #{fqdn} A
+        send
+      EOF
+
+      f.close_write
+    end
+  end
+  
+rescue => err
+  error("[#{err}]\n#{err.backtrace.join("\n")}")
+end

--- a/Automate/CloudFormsPOC/Integration/DynamicDNS/Methods.class/__methods__/delete_record.yaml
+++ b/Automate/CloudFormsPOC/Integration/DynamicDNS/Methods.class/__methods__/delete_record.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: delete_record
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs: []

--- a/Automate/CloudFormsPOC/Integration/DynamicDNS/Methods.class/addrecord.yaml
+++ b/Automate/CloudFormsPOC/Integration/DynamicDNS/Methods.class/addrecord.yaml
@@ -1,0 +1,18 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AddRecord
+    inherits: 
+    description: 
+  fields:
+  - servername:
+      value: ns1.example.com
+  - keyname:
+      value: cloudforms-key
+  - keyvalue:
+      value: v2:{lKcL8HFI0UrW281m+5VNRjGiDTNeAmZEKfoWtg5NntM=}
+  - method1:
+      value: add_record

--- a/Automate/CloudFormsPOC/Integration/DynamicDNS/Methods.class/deleterecord.yaml
+++ b/Automate/CloudFormsPOC/Integration/DynamicDNS/Methods.class/deleterecord.yaml
@@ -1,0 +1,18 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: DeleteRecord
+    inherits: 
+    description: 
+  fields:
+  - servername:
+      value: ns1.example.com
+  - keyname:
+      value: cloudforms-key
+  - keyvalue:
+      value: v2:{lKcL8HFI0UrW281m+5VNRjGiDTNeAmZEKfoWtg5NntM=}
+  - method1:
+      value: delete_record

--- a/Automate/CloudFormsPOC/Integration/DynamicDNS/__namespace__.yaml
+++ b/Automate/CloudFormsPOC/Integration/DynamicDNS/__namespace__.yaml
@@ -1,0 +1,11 @@
+---
+object_type: namespace
+version: 1.0
+object:
+  attributes:
+    name: DynamicDNS
+    description: 
+    display_name: 
+    system: 
+    priority: 
+    enabled: 


### PR DESCRIPTION
These methods use nsupdate to create and delete A records on a DNS server configured for dynamic updates. I used this to create DNS records on a bind server for VMs that automatically got their IP address from OpenStack.
