### PR TITLE
EVM 5.4 UI will hang if $evm.object['values'] is nill instead of empty

### DIFF
--- a/Automate/CloudFormsPOC/Integration/Chef/DynamicDropDowns.class/__methods__/chef_dialog_list.rb
+++ b/Automate/CloudFormsPOC/Integration/Chef/DynamicDropDowns.class/__methods__/chef_dialog_list.rb
@@ -85,7 +85,7 @@ begin
       first = chef_role unless first
       dialog_hash[chef_role] = chef_role
     }
-    dialog_hash[nil] = "< choose one >"
+    dialog_hash[''] = "< choose one >"
     log(:info, "Inspecting Values: #{build_dialog(dialog_hash).inspect}")
   else
     $evm.object['values'] = { nil => "< ERROR: contact administrator >"}

--- a/Automate/CloudFormsPOC/Integration/RedHat/OpenStack/DynamicDropDowns.class/__methods__/list_cloudinit_templates.rb
+++ b/Automate/CloudFormsPOC/Integration/RedHat/OpenStack/DynamicDropDowns.class/__methods__/list_cloudinit_templates.rb
@@ -15,6 +15,6 @@ for ct in list
   end
 end
 
-my_hash[nil] = nil
+my_hash[''] = nil
 $evm.object['values'] = my_hash
 $evm.log(:info, "Dynamic drop down values: #{$evm.object['values']}")

--- a/Automate/CloudFormsPOC/Integration/RedHat/OpenStack/DynamicDropDowns.class/__methods__/list_openstack_cloud_tenants.rb
+++ b/Automate/CloudFormsPOC/Integration/RedHat/OpenStack/DynamicDropDowns.class/__methods__/list_openstack_cloud_tenants.rb
@@ -92,9 +92,9 @@ begin
 
   if dialog_hash.blank?
     log(:info, "User has no access to tenants")
-    dialog_hash[nil] = "< No Tenant Access, Contact Administrator >"
+    dialog_hash[''] = "< No Tenant Access, Contact Administrator >"
   else
-      dialog_hash[nil] = '< choose a tenant >'
+      dialog_hash[''] = '< choose a tenant >'
   end
 
   $evm.object['values'] = dialog_hash

--- a/Automate/CloudFormsPOC/Integration/RedHat/OpenStack/DynamicDropDowns.class/__methods__/list_openstack_flavors_for_vm.rb
+++ b/Automate/CloudFormsPOC/Integration/RedHat/OpenStack/DynamicDropDowns.class/__methods__/list_openstack_flavors_for_vm.rb
@@ -32,7 +32,7 @@ begin
     log(:info, "Looking at flavor: #{fl.name} id: #{fl.id} cpus: #{fl.cpus} memory: #{fl.memory} ems_ref: #{fl.ems_ref}")
     next unless fl.ext_management_system || fl.enabled
     if fl.id == vm_flavor_id
-      dialog_hash[nil] = "<Current - #{fl.name}>"
+      dialog_hash[''] = "<Current - #{fl.name}>"
     else
       dialog_hash[fl.id] = "#{fl.name}"
     end

--- a/Automate/CloudFormsPOC/Integration/RedHat/OpenStack/DynamicDropDowns.class/__methods__/list_openstack_providers.rb
+++ b/Automate/CloudFormsPOC/Integration/RedHat/OpenStack/DynamicDropDowns.class/__methods__/list_openstack_providers.rb
@@ -62,10 +62,10 @@ begin
 
   if dialog_hash.blank?
     log(:info, "User: #{$evm.root['user'].name} has no access to Providers")
-    dialog_hash[nil] = "< No Providers Found for Tenant: #{tenant.name rescue 'unknown'}, Contact Administrator >"
+    dialog_hash[''] = "< No Providers Found for Tenant: #{tenant.name rescue 'unknown'}, Contact Administrator >"
   else
     #$evm.object['default_value'] = dialog_hash.first
-    dialog_hash[nil] = '< choose a provider >'
+    dialog_hash[''] = '< choose a provider >'
   end
 
   $evm.object['values'] = dialog_hash

--- a/Automate/CloudFormsPOC/Integration/RedHat/OpenStack/DynamicDropDowns.class/__methods__/list_openstack_server_groups.rb
+++ b/Automate/CloudFormsPOC/Integration/RedHat/OpenStack/DynamicDropDowns.class/__methods__/list_openstack_server_groups.rb
@@ -101,7 +101,7 @@ groups = list_groups(nova_url, token)
 log(:info, "All Groups: #{groups.inspect}")
 dialog_hash = {}
 groups.each { |group| dialog_hash[group["id"]] = "#{group["name"]} on #{provider.name}" }
-dialog_hash[nil] = "< Choose >"
+dialog_hash[''] = "< Choose >"
 $evm.object['values'] = dialog_hash
 log(:info, "Set Dialog Hash to #{dialog_hash.inspect}")
 log(:info, "Automate Method Ended")

--- a/Automate/CloudFormsPOC/Integration/RedHat/OpenStack/DynamicDropDowns.class/__methods__/list_openstack_tenant_networks.rb
+++ b/Automate/CloudFormsPOC/Integration/RedHat/OpenStack/DynamicDropDowns.class/__methods__/list_openstack_tenant_networks.rb
@@ -92,10 +92,10 @@ begin
 
   if dialog_hash.blank?
     log(:info, "User: #{$evm.root['user'].name} has no access to Tenant Networks")
-    dialog_hash[nil] = "< No Tenant Networks Found for Tenant: #{tenant_name}, Contact Administrator >"
+    dialog_hash[''] = "< No Tenant Networks Found for Tenant: #{tenant_name}, Contact Administrator >"
   else
     #$evm.object['default_value'] = dialog_hash.first
-    dialog_hash[nil] = '< choose a network >'
+    dialog_hash[''] = '< choose a network >'
   end
 
   $evm.object["values"]     = dialog_hash

--- a/Automate/CloudFormsPOC/Integration/RedHat/OpenStack/DynamicDropDowns.class/__methods__/listheattemplates.rb
+++ b/Automate/CloudFormsPOC/Integration/RedHat/OpenStack/DynamicDropDowns.class/__methods__/listheattemplates.rb
@@ -17,7 +17,7 @@ begin
     end
   end
 
-  my_hash[nil] = nil
+  my_hash[''] = nil
 
   $evm.object["sort_by"] = "description"
   $evm.object["sort_order"] = "ascending"

--- a/Automate/CloudFormsPOC/Integration/RedHat/RHEV/DynamicDropDowns.class/__methods__/list_rhev_templates_with_prov_scope.rb
+++ b/Automate/CloudFormsPOC/Integration/RedHat/RHEV/DynamicDropDowns.class/__methods__/list_rhev_templates_with_prov_scope.rb
@@ -35,9 +35,9 @@ begin
 
   if dialog_hash.blank?
     log(:info, "No Templates found - likely due to missing tag #{category}")
-    dialog_hash[nil] = "< No Templates found >"
+    dialog_hash[''] = "< No Templates found >"
   else
-    dialog_hash[nil] = '< choose a template >'
+    dialog_hash[''] = '< choose a template >'
   end
 
   $evm.object["values"]     = dialog_hash

--- a/Automate/CloudFormsPOC/Integration/VMware/DynamicDropDowns.class/__methods__/list_vmware_templates_with_prov_scope.rb
+++ b/Automate/CloudFormsPOC/Integration/VMware/DynamicDropDowns.class/__methods__/list_vmware_templates_with_prov_scope.rb
@@ -35,9 +35,9 @@ begin
 
   if dialog_hash.blank?
     log(:info, "No Templates found - likely due to missing tag #{category}")
-    dialog_hash[nil] = "< No Templates found >"
+    dialog_hash[''] = "< No Templates found >"
   else
-    dialog_hash[nil] = '< choose a template >'
+    dialog_hash[''] = '< choose a template >'
   end
 
   $evm.object["values"]     = dialog_hash


### PR DESCRIPTION
Several dynamic drop downs methods are implemented like:

dialog_hash[nil] = 'no value found'
$evm.object['values'] = dialog_hash

However, EVM 5.4 UI will hang on a refresh if this is used. Instead, the following should be used:

dialog_hash[''] = 'no value found'
$evm.object['values'] = dialog_hash

Modifications tested with the following methods:

/CloudFormsPOC/Integration/RedHat/OpenStack/DynamicDropDowns/list_openstack_providers
/CloudFormsPOC/Integration/RedHat/OpenStack/DynamicDropDowns/list_openstack_cloud_tenants
/CloudFormsPOC/Integration/RedHat/OpenStack/DynamicDropDowns/list_openstack_templates
/CloudFormsPOC/Integration/RedHat/OpenStack/DynamicDropDowns/listHeatTemplates
/CloudFormsPOC/Integration/RedHat/OpenStack/DynamicDropDowns/listTenantNetworks
